### PR TITLE
between

### DIFF
--- a/main.go
+++ b/main.go
@@ -97,3 +97,7 @@ func Parse(strs ...string) (time.Time, error) {
 func MustParse(strs ...string) time.Time {
 	return New(time.Now()).MustParse(strs...)
 }
+
+func Between(t time.Time, time1, time2 string) bool {
+	return New(t).Between(time1, time2)
+}

--- a/now.go
+++ b/now.go
@@ -166,3 +166,9 @@ func (now *Now) MustParse(strs ...string) (t time.Time) {
 	}
 	return t
 }
+
+func (now *Now) Between(time1, time2 string)bool {
+	restime := now.MustParse(time1)
+	restime2 := now.MustParse(time2)
+	return now.After(restime) && now.Before(restime2)
+}

--- a/now_test.go
+++ b/now_test.go
@@ -218,6 +218,17 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestBetween(t *testing.T) {
+	tm := time.Date(2015, 06, 30, 17, 51, 49, 123456789, time.Now().Location())
+	if !New(tm).Between("23:28:9 Dec 19, 2013 PST", "23:28:9 Dec 19, 2015 PST") {
+		t.Errorf("Between")
+	}
+
+	if !New(tm).Between("2015-05-12 12:20", "2015-06-30 17:51:50"){
+		t.Errorf("Between")
+	}
+}
+
 func Example() {
 	time.Now() // 2013-11-18 17:51:49.123456789 Mon
 


### PR DESCRIPTION
Hi!
I found that in the standard library "time", method Between(for checking is target time between first time and second) is missed, however, probably I was inattentive.
Anyway, i just implemented it:
```go
t := time.Date(2015, 06, 30, 17, 51, 49, 123456789, time.Now().Location())
fmt.Println(now.New(t).Between("2015-05-12 12:20", "2017-12-12 12:20"))
//=> true
```
Under the hood of this, is ```MustParse``` method, so input can gets any time format.