### PR TITLE
Added WeekStartDay so that any day can be the start of the week. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,25 @@ import "github.com/jinzhu/now"
 
 time.Now() // 2013-11-18 17:51:49.123456789 Mon
 
-now.BeginningOfMinute()   // 2013-11-18 17:51:00 Mon
-now.BeginningOfHour()     // 2013-11-18 17:00:00 Mon
-now.BeginningOfDay()      // 2013-11-18 00:00:00 Mon
-now.BeginningOfWeek()     // 2013-11-17 00:00:00 Sun
-now.FirstDayMonday = true // Set Monday as first day, default is Sunday
-now.BeginningOfWeek()     // 2013-11-18 00:00:00 Mon
-now.BeginningOfMonth()    // 2013-11-01 00:00:00 Fri
-now.BeginningOfQuarter()  // 2013-10-01 00:00:00 Tue
-now.BeginningOfYear()     // 2013-01-01 00:00:00 Tue
+now.BeginningOfMinute()        // 2013-11-18 17:51:00 Mon
+now.BeginningOfHour()          // 2013-11-18 17:00:00 Mon
+now.BeginningOfDay()           // 2013-11-18 00:00:00 Mon
+now.BeginningOfWeek()          // 2013-11-17 00:00:00 Sun
+now.WeekStartDay = time.Monday // Set Monday as first day, default is Sunday
+now.BeginningOfWeek()          // 2013-11-18 00:00:00 Mon
+now.BeginningOfMonth()         // 2013-11-01 00:00:00 Fri
+now.BeginningOfQuarter()       // 2013-10-01 00:00:00 Tue
+now.BeginningOfYear()          // 2013-01-01 00:00:00 Tue
 
-now.EndOfMinute()         // 2013-11-18 17:51:59.999999999 Mon
-now.EndOfHour()           // 2013-11-18 17:59:59.999999999 Mon
-now.EndOfDay()            // 2013-11-18 23:59:59.999999999 Mon
-now.EndOfWeek()           // 2013-11-23 23:59:59.999999999 Sat
-now.FirstDayMonday = true // Set Monday as first day, default is Sunday
-now.EndOfWeek()           // 2013-11-24 23:59:59.999999999 Sun
-now.EndOfMonth()          // 2013-11-30 23:59:59.999999999 Sat
-now.EndOfQuarter()        // 2013-12-31 23:59:59.999999999 Tue
-now.EndOfYear()           // 2013-12-31 23:59:59.999999999 Tue
+now.EndOfMinute()              // 2013-11-18 17:51:59.999999999 Mon
+now.EndOfHour()                // 2013-11-18 17:59:59.999999999 Mon
+now.EndOfDay()                 // 2013-11-18 23:59:59.999999999 Mon
+now.EndOfWeek()                // 2013-11-23 23:59:59.999999999 Sat
+now.WeekStartDay = time.Monday // Set Monday as first day, default is Sunday
+now.EndOfWeek()                // 2013-11-24 23:59:59.999999999 Sun
+now.EndOfMonth()               // 2013-11-30 23:59:59.999999999 Sat
+now.EndOfQuarter()             // 2013-12-31 23:59:59.999999999 Tue
+now.EndOfYear()                // 2013-12-31 23:59:59.999999999 Tue
 
 
 // Use another time

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ package now
 
 import "time"
 
-var FirstDayMonday bool
+var WeekStartDay = time.Sunday
 var TimeFormats = []string{"1/2/2006", "1/2/2006 15:4:5", "2006-1-2 15:4:5", "2006-1-2 15:4", "2006-1-2", "1-2", "15:4:5", "15:4", "15", "15:4:5 Jan 2, 2006 MST", "2006-01-02 15:04:05.999999999 -0700 MST"}
 
 type Now struct {

--- a/now.go
+++ b/now.go
@@ -22,11 +22,15 @@ func (now *Now) BeginningOfDay() time.Time {
 func (now *Now) BeginningOfWeek() time.Time {
 	t := now.BeginningOfDay()
 	weekday := int(t.Weekday())
-	if FirstDayMonday {
-		if weekday == 0 {
-			weekday = 7
+
+	if WeekStartDay != time.Sunday {
+		weekStartDayInt := int(WeekStartDay)
+
+		if weekday < weekStartDayInt {
+			weekday = weekday + 7 - weekStartDayInt
+		} else {
+			weekday = weekday - weekStartDayInt
 		}
-		weekday = weekday - 1
 	}
 
 	d := time.Duration(-weekday) * 24 * time.Hour

--- a/now_test.go
+++ b/now_test.go
@@ -28,15 +28,40 @@ func TestBeginningOf(t *testing.T) {
 		t.Errorf("BeginningOfDay")
 	}
 
-	if New(n).BeginningOfWeek().Format(format) != "2013-11-17 00:00:00" {
-		t.Errorf("BeginningOfWeek")
-	}
-
-	FirstDayMonday = true
+	WeekStartDay = time.Monday
 	if New(n).BeginningOfWeek().Format(format) != "2013-11-18 00:00:00" {
 		t.Errorf("BeginningOfWeek, FirstDayMonday")
 	}
-	FirstDayMonday = false
+
+	WeekStartDay = time.Tuesday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-12 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDayTuesday")
+	}
+
+	WeekStartDay = time.Wednesday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-13 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDayWednesday")
+	}
+
+	WeekStartDay = time.Thursday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-14 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDayThursday")
+	}
+
+	WeekStartDay = time.Friday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-15 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDayFriday")
+	}
+
+	WeekStartDay = time.Saturday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-16 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDaySaturday")
+	}
+
+	WeekStartDay = time.Sunday
+	if New(n).BeginningOfWeek().Format(format) != "2013-11-17 00:00:00" {
+		t.Errorf("BeginningOfWeek, FirstDaySunday")
+	}
 
 	if New(n).BeginningOfMonth().Format(format) != "2013-11-01 00:00:00" {
 		t.Errorf("BeginningOfMonth")
@@ -74,14 +99,39 @@ func TestEndOf(t *testing.T) {
 		t.Errorf("EndOfDay")
 	}
 
-	FirstDayMonday = true
+	WeekStartDay = time.Monday
 	if New(n).EndOfWeek().Format(format) != "2013-11-24 23:59:59.999999999" {
 		t.Errorf("EndOfWeek, FirstDayMonday")
 	}
 
-	FirstDayMonday = false
+	WeekStartDay = time.Tuesday
+	if New(n).EndOfWeek().Format(format) != "2013-11-18 23:59:59.999999999" {
+		t.Errorf("EndOfWeek, FirstDayTuesday")
+	}
+
+	WeekStartDay = time.Wednesday
+	if New(n).EndOfWeek().Format(format) != "2013-11-19 23:59:59.999999999" {
+		t.Errorf("EndOfWeek, FirstDayWednesday")
+	}
+
+	WeekStartDay = time.Thursday
+	if New(n).EndOfWeek().Format(format) != "2013-11-20 23:59:59.999999999" {
+		t.Errorf("EndOfWeek, FirstDayThursday")
+	}
+
+	WeekStartDay = time.Friday
+	if New(n).EndOfWeek().Format(format) != "2013-11-21 23:59:59.999999999" {
+		t.Errorf("EndOfWeek, FirstDayFriday")
+	}
+
+	WeekStartDay = time.Saturday
+	if New(n).EndOfWeek().Format(format) != "2013-11-22 23:59:59.999999999" {
+		t.Errorf("EndOfWeek, FirstDaySaturday")
+	}
+
+	WeekStartDay = time.Sunday
 	if New(n).EndOfWeek().Format(format) != "2013-11-23 23:59:59.999999999" {
-		t.Errorf("EndOfWeek")
+		t.Errorf("EndOfWeek, FirstDaySunday")
 	}
 
 	if New(n).EndOfMonth().Format(format) != "2013-11-30 23:59:59.999999999" {
@@ -143,7 +193,7 @@ func TestMondayAndSunday(t *testing.T) {
 		t.Errorf("BeginningOfWeek, FirstDayMonday")
 	}
 
-	FirstDayMonday = true
+	WeekStartDay = time.Monday
 	if New(n).BeginningOfWeek().Format(format) != "2013-11-18 00:00:00" {
 		t.Errorf("BeginningOfWeek, FirstDayMonday")
 	}
@@ -245,22 +295,22 @@ func Example() {
 	BeginningOfDay()    // 2013-11-18 00:00:00 Mon
 	BeginningOfWeek()   // 2013-11-17 00:00:00 Sun
 
-	FirstDayMonday = true // Set Monday as first day
-	BeginningOfWeek()     // 2013-11-18 00:00:00 Mon
-	BeginningOfMonth()    // 2013-11-01 00:00:00 Fri
-	BeginningOfQuarter()  // 2013-10-01 00:00:00 Tue
-	BeginningOfYear()     // 2013-01-01 00:00:00 Tue
+	WeekStartDay = time.Monday // Set Monday as first day
+	BeginningOfWeek()          // 2013-11-18 00:00:00 Mon
+	BeginningOfMonth()         // 2013-11-01 00:00:00 Fri
+	BeginningOfQuarter()       // 2013-10-01 00:00:00 Tue
+	BeginningOfYear()          // 2013-01-01 00:00:00 Tue
 
 	EndOfMinute() // 2013-11-18 17:51:59.999999999 Mon
 	EndOfHour()   // 2013-11-18 17:59:59.999999999 Mon
 	EndOfDay()    // 2013-11-18 23:59:59.999999999 Mon
 	EndOfWeek()   // 2013-11-23 23:59:59.999999999 Sat
 
-	FirstDayMonday = true // Set Monday as first day
-	EndOfWeek()           // 2013-11-24 23:59:59.999999999 Sun
-	EndOfMonth()          // 2013-11-30 23:59:59.999999999 Sat
-	EndOfQuarter()        // 2013-12-31 23:59:59.999999999 Tue
-	EndOfYear()           // 2013-12-31 23:59:59.999999999 Tue
+	WeekStartDay = time.Monday // Set Monday as first day
+	EndOfWeek()                // 2013-11-24 23:59:59.999999999 Sun
+	EndOfMonth()               // 2013-11-30 23:59:59.999999999 Sat
+	EndOfQuarter()             // 2013-12-31 23:59:59.999999999 Tue
+	EndOfYear()                // 2013-12-31 23:59:59.999999999 Tue
 
 	// Use another time
 	t := time.Date(2013, 02, 18, 17, 51, 49, 123456789, time.UTC)


### PR DESCRIPTION
My use case is that we let clients choose whatever start of week they want so it makes the BeginningOfWeek method not usable in some instances.

Allowing the user to set the week start as time.Monday is a little more elegant than setting a bool in my opinion. So although most people won't want the start of week to be Tuesday, this code change can still be viewed as an improvement.