### PR TITLE
Fix Parse Bug …

### DIFF
--- a/now.go
+++ b/now.go
@@ -141,7 +141,7 @@ func (now *Now) Parse(strs ...string) (t time.Time, err error) {
 				}
 
 				// Fill up missed information with current time
-				if v == 0 {
+				if v == 0 && i != 2 {
 					if setCurrentTime {
 						parseTime[i] = currentTime[i]
 					}


### PR DESCRIPTION
在解析“00:00:00”，小时为00时，会替换成当前时间的小时值。解析后会变成：“03:00:00”。

现在已经修复了……