### PR TITLE
Fix DST and Truncate bugs

### DIFF
--- a/now.go
+++ b/now.go
@@ -16,8 +16,8 @@ func (now *Now) BeginningOfHour() time.Time {
 }
 
 func (now *Now) BeginningOfDay() time.Time {
-	d := time.Duration(-now.Hour()) * time.Hour
-	return now.BeginningOfHour().Add(d)
+	y, m, d := now.Date()
+	return time.Date(y, m, d, 0, 0, 0, 0, now.Location())
 }
 
 func (now *Now) BeginningOfWeek() time.Time {
@@ -29,15 +29,12 @@ func (now *Now) BeginningOfWeek() time.Time {
 		}
 		weekday = weekday - 1
 	}
-
-	d := time.Duration(-weekday) * 24 * time.Hour
-	return t.Add(d)
+	return t.AddDate(0, 0, -weekday)
 }
 
 func (now *Now) BeginningOfMonth() time.Time {
-	t := now.BeginningOfDay()
-	d := time.Duration(-int(t.Day())+1) * 24 * time.Hour
-	return t.Add(d)
+	y, m, _ := now.Date()
+	return time.Date(y, m, 1, 0, 0, 0, 0, now.Location())
 }
 
 func (now *Now) BeginningOfQuarter() time.Time {
@@ -47,9 +44,8 @@ func (now *Now) BeginningOfQuarter() time.Time {
 }
 
 func (now *Now) BeginningOfYear() time.Time {
-	t := now.BeginningOfDay()
-	d := time.Duration(-int(t.YearDay())+1) * 24 * time.Hour
-	return t.Truncate(time.Hour).Add(d)
+	y, _, _ := now.Date()
+	return time.Date(y, time.January, 1, 0, 0, 0, 0, now.Location())
 }
 
 func (now *Now) EndOfMinute() time.Time {
@@ -61,7 +57,8 @@ func (now *Now) EndOfHour() time.Time {
 }
 
 func (now *Now) EndOfDay() time.Time {
-	return now.BeginningOfDay().Add(24*time.Hour - time.Nanosecond)
+	y, m, d := now.Date()
+	return time.Date(y, m, d, 23, 59, 59, int(time.Second-time.Nanosecond), now.Location())
 }
 
 func (now *Now) EndOfWeek() time.Time {
@@ -86,8 +83,7 @@ func (now *Now) Monday() time.Time {
 	if weekday == 0 {
 		weekday = 7
 	}
-	d := time.Duration(-weekday+1) * 24 * time.Hour
-	return t.Truncate(time.Hour).Add(d)
+	return t.AddDate(0, 0, -weekday+1)
 }
 
 func (now *Now) Sunday() time.Time {
@@ -96,13 +92,12 @@ func (now *Now) Sunday() time.Time {
 	if weekday == 0 {
 		return t
 	} else {
-		d := time.Duration(7-weekday) * 24 * time.Hour
-		return t.Truncate(time.Hour).Add(d)
+		return t.AddDate(0, 0, (7 - weekday))
 	}
 }
 
 func (now *Now) EndOfSunday() time.Time {
-	return now.Sunday().Add(24*time.Hour - time.Nanosecond)
+	return New(now.Sunday()).EndOfDay()
 }
 
 func parseWithFormat(str string) (t time.Time, err error) {

--- a/now.go
+++ b/now.go
@@ -11,7 +11,8 @@ func (now *Now) BeginningOfMinute() time.Time {
 }
 
 func (now *Now) BeginningOfHour() time.Time {
-	return now.Truncate(time.Hour)
+	y, m, d := now.Date()
+	return time.Date(y, m, d, now.Hour(), 0, 0, 0, now.Location())
 }
 
 func (now *Now) BeginningOfDay() time.Time {

--- a/now_test.go
+++ b/now_test.go
@@ -18,11 +18,23 @@ func TestBeginningOf(t *testing.T) {
 		t.Errorf("BeginningOfHour")
 	}
 
+	// Truncate with hour bug
+	location, err := time.LoadLocation("America/Caracas")
+	if err != nil {
+		t.Fatalf("Error loading location: %v", err)
+	}
+	if New(time.Date(2016, 1, 1, 12, 10, 0, 0, location)).BeginningOfHour().Format(format) != "2016-01-01 12:00:00" {
+		t.Errorf("BeginningOfHour Caracas")
+	}
+
 	if New(n).BeginningOfDay().Format(format) != "2013-11-18 00:00:00" {
 		t.Errorf("BeginningOfDay")
 	}
 
-	location, _ := time.LoadLocation("Japan")
+	location, err = time.LoadLocation("Japan")
+	if err != nil {
+		t.Fatalf("Error loading location: %v", err)
+	}
 	beginningOfDay := time.Date(2015, 05, 01, 0, 0, 0, 0, location)
 	if New(beginningOfDay).BeginningOfDay().Format(format) != "2015-05-01 00:00:00" {
 		t.Errorf("BeginningOfDay")


### PR DESCRIPTION
This fixes the incorrect use of Truncate with Hour (see https://github.com/golang/go/issues/16647) and it fixes bugs caused by DST.

This should fix #18 and #13 