### PR TITLE
Add parse in location to override local timezone

### DIFF
--- a/main.go
+++ b/main.go
@@ -94,8 +94,16 @@ func Parse(strs ...string) (time.Time, error) {
 	return New(time.Now()).Parse(strs...)
 }
 
+func ParseInLocation(loc *time.Location, strs ...string) (time.Time, error) {
+	return New(time.Now().In(loc)).Parse(strs...)
+}
+
 func MustParse(strs ...string) time.Time {
 	return New(time.Now()).MustParse(strs...)
+}
+
+func MustParseInLocation(loc *time.Location, strs ...string) time.Time {
+	return New(time.Now().In(loc)).MustParse(strs...)
 }
 
 func Between(time1, time2 string) bool {

--- a/now_test.go
+++ b/now_test.go
@@ -224,6 +224,11 @@ func TestParse(t *testing.T) {
 	if New(n2).MustParse("10:20").Location().String() != "PST" {
 		t.Errorf("Parse 10:20 shouldn't change time zone")
 	}
+
+	TimeFormats = append(TimeFormats, "2006-01-02T15:04:05.0")
+	if MustParseInLocation(time.UTC, "2018-02-13T15:17:06.0").String() != "2018-02-13 15:17:06 +0000 UTC" {
+		t.Errorf("ParseInLocation 2018-02-13T15:17:06.0")
+	}
 }
 
 func TestBetween(t *testing.T) {


### PR DESCRIPTION
In cases where the timezone is not present in the time string but is known to not be the timezone of local time.

For example:
A service provides timestamps in the format of: `2006-01-02T15:04:05.0` and the service explicitly defines these timestamps to be in UTC. However the local timezone is set as `PST`. The correct `time.Time` value can now be retrieved using:
```go
TimeFormats = append(TimeFormats, "2006-01-02T15:04:05.0")
t, err := now.ParseInLocation(time.UTC, timestring)
```