### PR TITLE
Add MonthAgo and MonthSince

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,23 @@ now.New(t).Sunday()       // 2013-11-24 00:00:00 Sun (Beginning Of Today if toda
 now.New(t).EndOfSunday()  // 2013-11-24 23:59:59.999999999 Sun (End of Today if today is Sunday)
 ```
 
+### MonthsAgo/MonthsSince
+
+MonthsAgo normalizes its result in the different way that AddDate, so, for example,
+calling one month ago from March 31 yields Feburary 28, the normalized from for Feburary 31.
+MonthsSince also.
+
+```go
+t1 := time.Date(2013, 03, 31, 17, 51, 49, 123456789, time.Now().Location())
+now.New(t1).MonthsAgo(1) // 2013-02-28 17:51:49.123456789
+
+// when leap year
+now.New(t1).MonthsAgo(13) // 2012-02-29 17:51:49.123456789
+
+t2 := time.Date(2013, 01, 31, 17, 51, 49, 123456789, time.Now().Location())
+now.New(t2).MonthsSince(1) // 2013-02-28 17:51:49.123456789
+```
+
 ### Parse String to Time
 
 ```go

--- a/now.go
+++ b/now.go
@@ -202,3 +202,12 @@ func (now *Now) Between(begin, end string) bool {
 	endTime := now.MustParse(end)
 	return now.After(beginTime) && now.Before(endTime)
 }
+
+// MonthsAgo returns time as n month ago
+func (now *Now) MonthsAgo(n int) time.Time {
+	t := now.AddDate(0, -n, 0)
+	if int(now.Day()) == int(t.Day()) {
+		return t
+	}
+	return t.AddDate(0, 0, -int(t.Day()))
+}

--- a/now.go
+++ b/now.go
@@ -211,3 +211,12 @@ func (now *Now) MonthsAgo(n int) time.Time {
 	}
 	return t.AddDate(0, 0, -int(t.Day()))
 }
+
+// MonthsSince returns time as n month later
+func (now *Now) MonthsSince(n int) time.Time {
+	t := now.AddDate(0, n, 0)
+	if int(now.Day()) == int(t.Day()) {
+		return t
+	}
+	return t.AddDate(0, 0, -int(t.Day()))
+}

--- a/now_test.go
+++ b/now_test.go
@@ -332,3 +332,11 @@ func Example() {
 	Sunday()      // 2013-11-24 00:00:00 Sun
 	EndOfSunday() // 2013-11-24 23:59:59.999999999 Sun
 }
+
+func TestMonthsAgo(t *testing.T) {
+	assert := assertT(t)
+	n := time.Date(2013, 3, 30, 17, 51, 49, 123456789, time.UTC)
+	assert(New(n).MonthsAgo(1), "2013-02-28 17:51:49.123456789", "1 month ago")
+	assert(New(n).MonthsAgo(3), "2012-12-30 17:51:49.123456789", "3 months ago")
+	assert(New(n).MonthsAgo(13), "2012-02-29 17:51:49.123456789", "13 months ago with leap year")
+}

--- a/now_test.go
+++ b/now_test.go
@@ -340,3 +340,11 @@ func TestMonthsAgo(t *testing.T) {
 	assert(New(n).MonthsAgo(3), "2012-12-30 17:51:49.123456789", "3 months ago")
 	assert(New(n).MonthsAgo(13), "2012-02-29 17:51:49.123456789", "13 months ago with leap year")
 }
+
+func TestMonthsSince(t *testing.T) {
+	assert := assertT(t)
+	n := time.Date(2013, 1, 31, 17, 51, 49, 123456789, time.UTC)
+	assert(New(n).MonthsSince(1), "2013-02-28 17:51:49.123456789", "1 month later")
+	assert(New(n).MonthsSince(3), "2013-04-30 17:51:49.123456789", "3 months later")
+	assert(New(n).MonthsSince(37), "2016-02-29 17:51:49.123456789", "37 months later with leap year")
+}


### PR DESCRIPTION
When acquiring the past or future time based on the month, `time.AddDate` does not return the expected value. So, I propose a method that behaves similarly to ActiveSuppot (Rails) 's `.months_ago` and `.months_since`.