### PR TITLE
Fuzzing integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,1 @@
+language: go

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,25 @@
+dist: bionic
 language: go
+go:
+  - "1.12.x"
+
+services:
+  - docker
+
+env:
+  global:
+    # FUZZIT_API_KEY
+    secure: "FEm1wF/Ttd5RIvDPg5I/aSAhBWuvkvjmkInFxlVKP4BfLsR1B1ogXV4zKFQiZugyppBta+qP4qP+tSbThSvP9JOCr+/ivnTyYLg/DH1RfQnC7rJmAaZwHGHB+NwblRzU621uIZ4RVvaE391YVJf5519gc+M+bxZ6DO0ScdpbIAVV/7JR9c7Tuvoyi57/MEwAS39k7h83ms8JgRYwuvzpVH9nb6AfYs+CzXuRlsG5mHqFnmzLyG0ewnqh18OoWbyKQwBmM+EoIGmckM8NQZaXWBhEuDP7qdl+QatNfZtK3YwBx2plahBXXMee3NpOAEHOkWxNw1uMb1B8ILDrzrx8oX1A4fF/ZeJl7JLZS/fQUMhDnLG5soA0xaEoAvwhQIHFi3e207rsq9UJsnQlRGhRWzMvx85UR5z+yiur8nVUkogu1DGpH/BPdWbTs+d8behSr7t6Sepo7enjJOPJLz6U67JlP31HvnaLICMEXxJy54BAbdu/47vqFp15lcIMHyDzPltHHWi6uGuRFQPYz8pM5ZAKQ945dO/ZELyEHbjUiLTMFeVoANzahuY56BX6hvsygcOlBWB6ukoJANvxgvM/QYkbh9dMBajYsZqHCWOKRVbBakkqPAUqkBNPOADTp5ZgUwmRySIGzX2X+Efl7cFYZVu+IJl968F8hqYajvS/VCs="
+
+jobs:
+  include:
+    - stage: Fuzz regression
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh local-regression
+
+    - stage: Fuzz
+      if: type IN (push)
+      go: 1.12.x
+      script:
+        - ./fuzzit.sh fuzzing

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 Now is a time toolkit for golang
 
 [![wercker status](https://app.wercker.com/status/a350da4eae6cb28a35687ba41afb565a/s/master "wercker status")](https://app.wercker.com/project/byKey/a350da4eae6cb28a35687ba41afb565a)
+[![fuzzit status](https://app.fuzzit.dev/badge?org_id=jinzhu)](https://app.fuzzit.dev/orgs/jinzhu/dashboard)
 
 ## Install
 

--- a/fuzzit.sh
+++ b/fuzzit.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -xe
+
+NAME=now
+TYPE=$1
+
+function fuzz {
+    TARGET=$NAME-$1
+    FUNCTION=Fuzz$2
+    go-fuzz-build -libfuzzer -func $FUNCTION -o $NAME.a .
+    clang -fsanitize=fuzzer $NAME.a -o $NAME
+    ./fuzzit create job --type $TYPE $TARGET $NAME
+}
+
+# Setup
+export GO111MODULE="off"
+go get -u github.com/dvyukov/go-fuzz/go-fuzz github.com/dvyukov/go-fuzz/go-fuzz-build
+go get -d -v -u ./...
+wget -q -O fuzzit https://github.com/fuzzitdev/fuzzit/releases/download/v2.4.29/fuzzit_Linux_x86_64
+chmod a+x fuzzit
+
+# Fuzz
+fuzz parse Parse
+fuzz api API

--- a/now_fuzz.go
+++ b/now_fuzz.go
@@ -1,0 +1,65 @@
+// +build gofuzz
+
+package now
+
+import (
+	"time"
+)
+
+func FuzzParse(input []byte) int {
+	_, err := Parse(string(input))
+	if err != nil {
+		return 0
+	}
+	return 1
+}
+
+// Maps bytes to API calls
+func FuzzAPI(program []byte) int {
+	t := New(time.Unix(1, 0))
+	for _, step := range program {
+		switch step {
+		case 0:
+			t = New(t.BeginningOfDay())
+		case 1:
+			t = New(t.BeginningOfHalf())
+		case 2:
+			t = New(t.BeginningOfHour())
+		case 3:
+			t = New(t.BeginningOfMinute())
+		case 4:
+			t = New(t.BeginningOfMonth())
+		case 5:
+			t = New(t.BeginningOfQuarter())
+		case 6:
+			t = New(t.BeginningOfWeek())
+		case 7:
+			t = New(t.BeginningOfYear())
+		case 8:
+			t = New(t.EndOfDay())
+		case 9:
+			t = New(t.EndOfHalf())
+		case 10:
+			t = New(t.EndOfHour())
+		case 11:
+			t = New(t.EndOfMinute())
+		case 12:
+			t = New(t.EndOfMonth())
+		case 13:
+			t = New(t.EndOfQuarter())
+		case 14:
+			t = New(t.EndOfSunday())
+		case 15:
+			t = New(t.EndOfWeek())
+		case 16:
+			t = New(t.EndOfYear())
+		case 17:
+			t = New(t.Monday())
+		case 18:
+			t = New(t.Sunday())
+		default:
+			return -1
+		}
+	}
+	return 1
+}


### PR DESCRIPTION
Hi guys. What would you think about integrating with a fuzzing service? Proposing here to get it running on [Fuzzit](https://fuzzit.dev/). They give free service for open source.

This patch fuzzes `Parse()` with binary data. It also fuzzes the API by mapping bytes to API calls, so it runs through different sequences of API calls looking for crashes.

If you're interested setup is like this:
* Enable the repo in [Travis](https://travis-ci.org/).
* In Fuzzit create targets `now-parse` `now-api`.
* In Fuzzit settings grab an API key. In repo settings in Travis paste it to a new envvar `FUZZIT_API_KEY`.